### PR TITLE
Fix ECS execute-command for migrations

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -214,6 +214,11 @@ jobs:
             --output text)
           echo "task_arn=$TASK_ARN" >> $GITHUB_OUTPUT
 
+      - name: Install Session Manager plugin
+        run: |
+          curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "session-manager-plugin.deb"
+          sudo dpkg -i session-manager-plugin.deb
+
       - name: Run migrations
         run: |
           aws ecs execute-command \
@@ -221,7 +226,7 @@ jobs:
             --task ${{ steps.task.outputs.task_arn }} \
             --container web \
             --command "python manage.py migrate --noinput" \
-            --non-interactive
+            --interactive
 
   # Notify on completion
   notify:


### PR DESCRIPTION
## Summary
- Fix ECS execute-command to use `--interactive` flag (only supported mode)
- Add Session Manager plugin installation step

## Previous fix included
- Add COOKIE_DOMAIN build-time placeholder for Docker build

🤖 Generated with [Claude Code](https://claude.com/claude-code)