### PR TITLE
Fix approval email button visibility and signup URL

### DIFF
--- a/core/users/invitation_views.py
+++ b/core/users/invitation_views.py
@@ -321,7 +321,7 @@ def send_approval_email(invitation: InvitationRequest):
     context = {
         'requester_name': invitation.name,
         'requester_email': invitation.email,
-        'signup_url': f'{frontend_url}/auth/signup?beta=THRIVE&email={invitation.email}',
+        'signup_url': f'{frontend_url}/auth?beta=THRIVE&email={invitation.email}',
         'frontend_url': frontend_url,
         'current_year': timezone.now().year,
         'settings_url': f'{frontend_url}/settings/notifications',

--- a/templates/emails/base.html
+++ b/templates/emails/base.html
@@ -109,10 +109,11 @@
             border: 1px solid rgba(34, 197, 94, 0.3);
         }
 
-        /* Button */
+        /* Button - using solid color for email client compatibility */
         .btn {
             display: inline-block;
             padding: 14px 28px;
+            background-color: #22d3ee;
             background: linear-gradient(135deg, #22d3ee 0%, #a855f7 100%);
             color: #0f172a !important;
             text-decoration: none;

--- a/templates/emails/invitations/approved.html
+++ b/templates/emails/invitations/approved.html
@@ -14,9 +14,20 @@
     Click the button below to create your account and start building your AI portfolio.
 </div>
 
-<p style="text-align: center;">
-    <a href="{{ signup_url }}" class="btn">Create Your Account</a>
-</p>
+<!-- Table-based button for maximum email client compatibility -->
+<table cellpadding="0" cellspacing="0" border="0" width="100%" style="margin: 20px 0;">
+    <tr>
+        <td align="center">
+            <table cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                    <td align="center" bgcolor="#22d3ee" style="background-color: #22d3ee; border-radius: 8px;">
+                        <a href="{{ signup_url }}" target="_blank" style="display: inline-block; padding: 14px 28px; font-size: 16px; font-weight: 600; color: #0f172a; text-decoration: none; border-radius: 8px;">Create Your Account</a>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
 
 <h2>What you can do on All Thrive:</h2>
 <ul style="color: #cbd5e1; line-height: 1.8;">


### PR DESCRIPTION
## Summary
- Add solid background-color fallback in email button CSS for email clients that do not support CSS gradients
- Replace CSS-only button with table-based button in approval email for maximum email client compatibility
- Fix signup URL from /auth/signup to /auth so the beta code auto-fills correctly

## Test plan
- [ ] Send a test approval email and verify the Create Your Account button is visible
- [ ] Click the button and verify it navigates to /auth?beta=THRIVE&email=...
- [ ] Verify the beta code field auto-populates with THRIVE

Generated with Claude Code